### PR TITLE
Allow script to run sooner

### DIFF
--- a/zammad_custom.user.js
+++ b/zammad_custom.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name     Zammad customizations
 // @match    https://help.vates.tech/*
-// @version  2025-03-11
+// @version  2025-08-19
 // @license      GPL-v3
 // @author       DanP2
 // @require            https://code.jquery.com/jquery-3.6.0.min.js

--- a/zammad_custom.user.js
+++ b/zammad_custom.user.js
@@ -15,15 +15,17 @@
 // @grant              GM_registerMenuCommand
 // @grant              GM_addStyle
 // @grant              GM_getResourceText
-// @icon https://avatars.githubusercontent.com/u/1380327?s=200&v=4
-// @run-at   document-idle
-// @description Customize Zammad
+// @icon               https://avatars.githubusercontent.com/u/1380327?s=200&v=4
+// @run-at             document-start
+// @description        Customize Zammad
 // ==/UserScript==
 
 (function() {
     'use strict';
 
     console.log(`Starting ${GM_info.script.name} version ${GM_info.script.version}...`);
+
+    checkExistingInstance();
 
     const disabledHotkeys = [
         // {saveName: "disableUpdateClosed", hotkey: "ctrl+shift+c", default: true, desc: "Update as closed"},
@@ -156,8 +158,6 @@
         const blockedContentSelector = "div.remote-content-message";
         const navigationPaneSelector = "div#navigation";
         const tabCloseSelector = "nav-tab-close-inner";
-
-        checkExistingInstance();
 
         GM_registerMenuCommand(`${GM_info.script.name} Settings`, () => {
             gmc.open();


### PR DESCRIPTION
- Use document-start instead of document-idle
- Move checkExistingInstance to beginning of script

Signed-off-by: Dan Pollak <danpollak2@gmail.com>